### PR TITLE
Quick dirty patch to test hypothesis and fix (if it is the issue) for single height case

### DIFF
--- a/chain/events/filter/event.go
+++ b/chain/events/filter/event.go
@@ -387,6 +387,19 @@ func (m *EventFilterManager) Install(ctx context.Context, minHeight, maxHeight a
 	}
 
 	if m.EventIndex != nil && minHeight != -1 && minHeight < currentHeight {
+		// hacky fix to fix issue with non-canonical log results being returned
+		// only works when the filter has the same start and stop height
+		if minHeight == maxHeight {
+			canonicalTipSet, err := m.ChainStore.GetTipsetByHeight(ctx, minHeight, nil, false)
+			if err != nil {
+				return nil, err
+			}
+			canonicalTipSetCID, err := canonicalTipSet.Key().Cid()
+			if err != nil {
+				return nil, err
+			}
+			f.tipsetCid = canonicalTipSetCID
+		}
 		// Filter needs historic events
 		if err := m.EventIndex.PrefillFilter(ctx, f); err != nil {
 			return nil, err


### PR DESCRIPTION
For log filter criteria with minHeight == maxHeight (one block) resolve the height to a tipsetkeycid before querying the events.db, to exclude any non-canonical results (quick dirty fix, need a proper fix to handle range queries)